### PR TITLE
Adding support for --build-arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The accepted inputs are:
 | `tag`         | String    | `latest`  | No          | Tags (*comma separated*) to apply to the image                  |
 | `imageName`   | String    |   | Yes         | Name of the image                                               |
 | `dockerFile`  | String    | `Dockerfile` | No       | Name of the Dockerfile |
+| `buildArg`    | String    | `none`       | No       | Docker build `--build-arg` flags (*comma separated*) |
 | `publish`     | Boolean   | `false`   | No          | Indicate if the builded image should be published on Docker HUB |
 | `platform`    | String    | `linux/amd64,linux/arm64,linux/arm/v7`  | No         | Platforms (*comma separated*) that should be used to build the image |                 |
 | `dockerHubUser`   | String    |   | Only if `publish` is true         | User that will publish the image                 |

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     dockerFile:
         description: "Name of the Dockerfile"
         default: "Dockerfile"
+    buildArg:
+        description: "Docker `--build-arg` flags (*comma separated*)"
+        default: "none"
     publish:
         description: "Indicate if the builded image should be published on Docker HUB"
         default: "false"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,8 +1,4 @@
 #!/bin/sh -l
 export DOCKER_CLI_EXPERIMENTAL=enabled
-DOCKER_BUILDX_TAG_OPTS=
-for TAG in $(echo "$3" | tr ',' ' ')
-do
-    DOCKER_BUILDX_TAG_OPTS="$DOCKER_BUILDX_TAG_OPTS --tag $2:$TAG"
-done
-docker buildx build --platform $1 $DOCKER_BUILDX_TAG_OPTS -f $4 .
+
+docker buildx build $@ .

--- a/scripts/docker_build_push.sh
+++ b/scripts/docker_build_push.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -l
-export DOCKER_CLI_EXPERIMENTAL=enabled
-DOCKER_BUILDX_TAG_OPTS=
-for TAG in $(echo "$3" | tr ',' ' ')
-do
-    DOCKER_BUILDX_TAG_OPTS="$DOCKER_BUILDX_TAG_OPTS --tag $2:$TAG"
-done
-docker buildx build --platform $1 --push $DOCKER_BUILDX_TAG_OPTS -f $4 .

--- a/scripts/docker_login.sh
+++ b/scripts/docker_login.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+echo $2 | docker login --username $1 --password-stdin

--- a/scripts/dockerhub_login.sh
+++ b/scripts/dockerhub_login.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -l
-
-docker login -u $1 -p $2


### PR DESCRIPTION
This also includes couple restructuring to make maintenance easier:
  - Move argument parsing into JS code
  - Consolidate docker build scripts
  - Remove 'sudo' call and keep this action run under user-mode